### PR TITLE
Updated mastodon.rake so that users aren't misled

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -20,7 +20,7 @@ namespace :mastodon do
       errors = false
 
       prompt.say('Your instance is identified by its domain name. Changing it afterward will break things.')
-      env['LOCAL_DOMAIN'] = prompt.ask('Domain name:') do |q|
+      env['LOCAL_DOMAIN'] = prompt.ask('Domain name or IP:') do |q|
         q.required true
         q.modify :strip
         q.validate(/\A[a-z0-9.-]+\z/i)


### PR DESCRIPTION
Updated mastodon.rake so that users aren't misled by the text, and know that this field can be an IP.